### PR TITLE
[DIEVT-3189] Fix: change BASE_URL constant to string

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/src/events/common/helpers/strings/constants.ts
+++ b/src/events/common/helpers/strings/constants.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = new URL("https://api.event.linximpulse.net/v7/events/views")
+export const BASE_URL = 'https://api.event.linximpulse.net/v7/events/views'
 export const COOKIE_BROWSER_ID = 'chaordic_browserId'
 export const COOKIE_SESSION = 'impulsesuite_session'
 export const COOKIE_ANON_USER_ID = 'chaordic_anonymousUserId'

--- a/src/events/common/services/Event.ts
+++ b/src/events/common/services/Event.ts
@@ -134,9 +134,8 @@ export abstract class Event<T extends DefaultOutputValidation = DefaultOutputVal
     async send(eventData?: RequiredOnly<T> | OptionalsOnly<T>): Promise<any | Error> { 
         try {
             const parser = new ParserSchema(this.schema)
-            
             const options = await new Request(
-                new URL(`${BASE_URL.href}/${this.path}`),
+                new URL(`${BASE_URL}/${this.path}`),
                 'POST',
                 parser.validate({...this.data, ...eventData})
             )


### PR DESCRIPTION
## Description

There was a bug for react native development in which there was a duplication of the `/` because of the `href` method of the `URL` object added a forward slash in the end of the string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://jira.linx.com.br/browse/DIEVT-3189

```javascript
export const BASE_URL = new URL("https://api.event.linximpulse.net/v7/events/views")
....
new URL(`${BASE_URL}/${this.path}`)
```

![image](https://github.com/chaordic/impulse-sdk-js/assets/26423380/51140a73-7458-4205-a323-ff64c26120ad)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.