### PR TITLE
[DIEVT-3189] Fix: replace all URL type object for string

### DIFF
--- a/src/events/common/services/Event.ts
+++ b/src/events/common/services/Event.ts
@@ -134,8 +134,9 @@ export abstract class Event<T extends DefaultOutputValidation = DefaultOutputVal
     async send(eventData?: RequiredOnly<T> | OptionalsOnly<T>): Promise<any | Error> { 
         try {
             const parser = new ParserSchema(this.schema)
+            const url = `${BASE_URL}/${this.path}`
             const options = await new Request(
-                new URL(`${BASE_URL}/${this.path}`),
+                url,
                 'POST',
                 parser.validate({...this.data, ...eventData})
             )

--- a/src/events/infrastructure/axios/requests/request-generator.ts
+++ b/src/events/infrastructure/axios/requests/request-generator.ts
@@ -26,7 +26,7 @@ export type RequestMethod =
 export class Request {
 
   constructor(
-    readonly baseEndpoint: URL,
+    readonly baseEndpoint: string,
     readonly method: RequestMethod,
     readonly bodyContent?: any,
     readonly pathParams?: RequestParamValue,
@@ -45,21 +45,21 @@ export class Request {
 
   async build(): Promise<AxiosRequestConfig> {
     const headers: AxiosHeaders = setHeaders(this.headerParams, this.bodyContent.domain);
-    const url: URL = makeUrl(this.baseEndpoint, this.queryParams);
+    const url: string = makeUrl(this.baseEndpoint, this.queryParams);
     let body: any = this.bodyContent;
 
     if (body === "{}") {
       return {
         method: `${this.method}`,
         headers: headers,
-        url: url.href
+        url
       };
     }
 
     return {
       method: `${this.method}`,
       headers: headers,
-      url: url.href,
+      url,
       data: body
     }
   }
@@ -94,10 +94,10 @@ function setHeaders(headerParams: RequestParamValue, domain?: string): AxiosHead
   return new AxiosHeaders(defaultHeader) 
 }
 
-function makeUrl(path: URL, queryParams: RequestParamValue): URL {  
+function makeUrl(path: string, queryParams: RequestParamValue): string {  
   if (queryParams !== undefined) {
     const queryString: URLSearchParams = new URLSearchParams(`${queryParams}`);
-    return new URL(`${path.href}?${queryString}`);
+    return `${path}?${queryString}`;
   }
 
   return path;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Replace all call for object type URL for a string value, since it was adding an extra `/ `at the POST request.

![image](https://github.com/chaordic/impulse-sdk-js/assets/26423380/db7e64ab-c5a9-43da-9bc6-3c4f1a8d4589)


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.linx.com.br/browse/DIEVT-3189

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.